### PR TITLE
Fixed swapped strings passed into dlfcns

### DIFF
--- a/example/enzyme_setup.py
+++ b/example/enzyme_setup.py
@@ -3,8 +3,8 @@ import enzyme
 p = enzyme.setup(
 	# need a good amount of code cave space
 	code_caves = ( (0xc7bb0, 0xc7c0c), (0xc7c14, 0xc7c58), (0xc7c74, 0xc7ca4), (0xc7e08, 0xc7e4c) ),
-	# 12 bytes and 28 bytes respectively
-	data_caves = (0x5ef035, 0x5ef041),
+	# 28 bytes and 12 bytes respectively
+	data_caves = (0x5ef041,0x5ef035),
 	# 8 bytes of writable bss space
 	bss_cave = 0x7cdb90,
 	# address of the dlopen stub

--- a/patcher/enzyme.py
+++ b/patcher/enzyme.py
@@ -5,8 +5,8 @@ import os
 def setup(code_caves, data_caves, bss_cave, dlopen_stub, dlsym_stub):
     p = patcher.Patcher(sys.argv[1])
 
-    p.bin_patch(data_caves[0], b"findthehook")
-    p.bin_patch(data_caves[1], b"@executable_path/hook.dylib")
+    p.bin_patch(data_caves[0], b"@executable_path/hook.dylib")
+    p.bin_patch(data_caves[1], b"findthehook")
 
     for i in code_caves:
         p.code_cave(i[0], i[1])


### PR DESCRIPTION
I Found null was being returned from bl $getfindhook which resulted in a crash on the next instruction. I disassembled the modified binary and found that the strings passed into the dl functions were swapped. 